### PR TITLE
Fix #3: Failed to install (or upgrade) pbkit

### DIFF
--- a/Formula/pbkit.rb
+++ b/Formula/pbkit.rb
@@ -8,8 +8,8 @@ class Pbkit < Formula
   def install
     mkdir_p libexec
     system "mv ./* #{libexec}/"
-    system "deno", "install", "--root", libexec, "-n", "pb", "-A", "--no-check", "--unstable", libexec/"cli/pb/entrypoint.ts"
-    system "deno", "install", "--root", libexec, "-n", "pollapo", "-A", "--no-check", "--unstable", libexec/"cli/pollapo/entrypoint.ts"
+    system "deno", "install", "--global", "--root", libexec, "-n", "pb", "-A", "--no-check", "--unstable-kv", "--unstable-cron", libexec/"cli/pb/entrypoint.ts"
+    system "deno", "install", "--global", "--root", libexec, "-n", "pollapo", "-A", "--no-check", "--unstable-kv", "--unstable-cron", libexec/"cli/pollapo/entrypoint.ts"
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 end


### PR DESCRIPTION
This PR:

- Adds a missing `--global` flag to both `deno install` invocations (fixes #3)
- Replaces the deprecated `--unstable` flag with the two [granular flags recommended by the Deno docs](https://docs.deno.com/runtime/reference/cli/unstable_flags/#--unstable): `--unstable-kv` and `--unstable-cron` (I'm not sure which one(s) are necessary, so I added both to be safe)